### PR TITLE
docs: Correct `preact-compat` reference in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Preact Island helps you build these experiences by adding a lightweight layer on
 - 🧼 Does not mutate the `window`. Use as many islands as you'd like on one page!
 - 🐣 Less than 1.3kB
 - ☠️ Supports replacing the target selector
-- 🏔 React friendly with `preact-compat`
+- 🏔 React friendly with `preact/compat`
 - 🔧 Manually trigger rerenders with props
 - 🐙 Fully tested with Preact testing library
 - 👔 Fully typed with TypeScript


### PR DESCRIPTION
Small typo.

[`preact-compat` is the legacy compat, only used in Preact 8 and older.](https://github.com/preactjs/preact-compat/#attention-preact-compat-has-moved-to-the-main-repo) As this project has a peer dependency on Preact > 10. definitely need to be using `preact/compat`.

Looks really cool btw!