### PR TITLE
fix: Preact peerDep version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "typescript": "^4.6.4"
   },
   "peerDependencies": {
-    "preact": ">10"
+    "preact": ">=10"
   }
 }


### PR DESCRIPTION
The peerDep version range is currently impossible to satisfy: https://semver.npmjs.com/